### PR TITLE
Changed the definitions structure to group lifecycle methods together

### DIFF
--- a/src/classes/sequencer.js
+++ b/src/classes/sequencer.js
@@ -44,9 +44,22 @@ export default class {
                     break;
             }
             //let target = sequenceStep.target === 'state' ? this.state.scoped : this.component.scoped;
-            const actionHook = common.hookString(hook, sequenceStep.action);
-            if(target[actionHook]) {
-                const res = target[actionHook].apply(target, params);
+            // const actionHook = common.hookString(hook, sequenceStep.action);
+            const hasLifecycle = !!target.lifecycle;
+            let action = false;
+
+            if(hasLifecycle) {
+                const hookKey = hook || 'on';
+                const hasHook = !!target.lifecycle[hookKey];
+                if(hasHook) {
+                    action = target.lifecycle[hookKey][sequenceStep.action];
+                }
+                if(!action && !hook) {
+                    action = target.lifecycle[sequenceStep.action]
+                }
+            }
+            if(action) {
+                const res = action.apply(target, params);
                 if(res === false) {
                     return false;
                 }

--- a/test-example-app/components/counter.js
+++ b/test-example-app/components/counter.js
@@ -17,17 +17,19 @@ export default SepCon.createComponent({
         },
     },
     view: {
-        'render'() {
-            const button = DescribedButton.createTag()
-                .props({label: 'This is a simple counter button'})
-                .refMethods({onclick: 'increase'});
+        lifecycle: {
+            render() {
+                const button = DescribedButton.createTag()
+                    .props({label: 'This is a simple counter button'})
+                    .refMethods({onclick: 'increase'});
 
-            return `
+                return `
                     <div class="sepcon sepcon-component">
                         ${button.render('open')}
                             <div>Clicked <span class="underline">${this.props.count}</span> times</div>
                         ${button.render('close')}
                     </div>`;
+            }
         }
     },
     increaseCounter(e) {

--- a/test-example-app/components/header.js
+++ b/test-example-app/components/header.js
@@ -13,15 +13,19 @@ SepCon.createComponent({
                 }
             }
         },
-        mount() {
-            console.log('the decorator "mount"', this);
-            this.methods.local.debug.call(this);
+        lifecycle: {
+            mount() {
+                console.log('the decorator "mount"', this);
+                this.methods.local.debug.call(this);
+            }
         }
     },
     view: {
-        render() {
-            console.log('the decorator "render"', this);
-            this.debugComponent();
+        lifecycle: {
+            render() {
+                console.log('the decorator "render"', this);
+                this.debugComponent();
+            }
         },
         debugComponent() {
             console.log('the decorator "debugComponent', this);
@@ -70,21 +74,23 @@ export default SepCon.createComponent({
             {event: 'click', selector: 'div#dfg5e3dfg', handler: 'dfsgdfgs'},
             {event: 'click', selector: 'div', handler: 'dfsgdfgs'},
         ],
-        'render'() {
-            console.log('the actual component "render"', this);
-            this.methods.debug();
-            if (!this.props.currentPage) {
-                return '';
-            }
-            const title = TextHolder.createTag()
-                .props({value: this.props.currentPage.title});
-            const description = TextHolder.createTag()
-                .props({value: this.props.currentPage.description});
-            return `
+        lifecycle: {
+            render() {
+                console.log('the actual component "render"', this);
+                this.methods.debug();
+                if (!this.props.currentPage) {
+                    return '';
+                }
+                const title = TextHolder.createTag()
+                    .props({value: this.props.currentPage.title});
+                const description = TextHolder.createTag()
+                    .props({value: this.props.currentPage.description});
+                return `
                     <div class="sepcon sepcon-component">
                         ${title.render()}
                         ${description.render()}
                     </div>`;
+            }
         },
         debugComponent() {
             console.log('the actual component "debugComponent', this);

--- a/test-example-app/components/numbers-presentor.js
+++ b/test-example-app/components/numbers-presentor.js
@@ -12,20 +12,23 @@ const numberPresentor = SepCon.createComponent({
                 number: null,
             },
         },
-        change(changed) {
-            if (this.props.external.index === '1') {
-                console.log('do not render change for number index 1 - referenced value should still get updated');
-                return false;
+        lifecycle: {
+            change(changed) {
+                if (this.props.external.index === '1') {
+                    console.log('do not render change for number index 1 - referenced value should still get updated');
+                    return false;
+                }
             }
         }
     },
     view: {
-        render() {
-            const text = TextHolder.createTag()
-                .refProps({
-                    value: 'number'
-                });
-            return `
+        lifecycle: {
+            render() {
+                const text = TextHolder.createTag()
+                    .refProps({
+                        value: 'number'
+                    });
+                return `
                     <div class="sepcon sepcon-component">
                         ${this.props.index === '1' ? `<div class="redText">Do not re-render on change</div>` : ''}
                         Index: ${this.props.index} -
@@ -35,6 +38,7 @@ const numberPresentor = SepCon.createComponent({
                             ${text.render()}
                         </div>
                     </div>`;
+            }
         }
     }
 });
@@ -54,34 +58,37 @@ export default SepCon.createComponent({
                 }
             }
         },
-        change(changed) {
-            this.setProps({
-                changes: this.props.local.changes + 1
-            }, true);
-            if (changed.list && Object.keys(changed.list.newValue).length != Object.keys(changed.list.oldValue).length) {
-                return true;
+        lifecycle: {
+            change(changed) {
+                this.setProps({
+                    changes: this.props.local.changes + 1
+                }, true);
+                if (changed.list && Object.keys(changed.list.newValue).length != Object.keys(changed.list.oldValue).length) {
+                    return true;
+                }
+                return false;
             }
-            return false;
         }
     },
     view: {
-        render() {
-            const text = TextHolder.createTag()
-                .refProps({
-                    value: 'changes'
-                });
-            let numbers = [];
-            for (let index in this.props.list) {
-                numbers.push(numberPresentor.createTag()
-                    .id(index)
-                    .props({
-                        index
-                    })
+        lifecycle: {
+            render() {
+                const text = TextHolder.createTag()
                     .refProps({
-                        number: 'list.' + index
-                    }));
-            }
-            return `
+                        value: 'changes'
+                    });
+                let numbers = [];
+                for (let index in this.props.list) {
+                    numbers.push(numberPresentor.createTag()
+                        .id(index)
+                        .props({
+                            index
+                        })
+                        .refProps({
+                            number: 'list.' + index
+                        }));
+                }
+                return `
                     <div class="sepcon sepcon-container">
                         <div class="flex-container">
                             ${numbers.map((item)=>item.render()).join('')}
@@ -89,6 +96,7 @@ export default SepCon.createComponent({
                         <h5>Numbers data have been changed: </h5>
                         ${text.render()}
                     </div>`;
+            }
         }
     }
 });

--- a/test-example-app/components/one-number-changer.js
+++ b/test-example-app/components/one-number-changer.js
@@ -54,22 +54,24 @@ export default SepCon.createComponent({
                 }
             }
         },
-        mount() {
-            this.updateProps();
-        },
-        change(changed) {
-            if (this.props.local.isFocused) {
-                if (changed.value) {
-                    this.methods.global.update();
+        lifecycle: {
+            mount() {
+                this.updateProps();
+            },
+            change(changed) {
+                if (this.props.local.isFocused) {
+                    if (changed.value) {
+                        this.methods.global.update();
+                    }
+                    if (changed.listForChange && Object.keys(this.props.global.listForChange).length > this.props.local.indexes.length) {
+                        this.updateProps();
+                        return true;
+                    }
+                    return false;
                 }
-                if (changed.listForChange && Object.keys(this.props.global.listForChange).length > this.props.local.indexes.length) {
-                    this.updateProps();
-                    return true;
-                }
-                return false;
+                this.updateProps();
+                return true;
             }
-            this.updateProps();
-            return true;
         },
         updateProps() {
             if (!Object.keys(this.props.global.listForChange).length) return;
@@ -92,53 +94,59 @@ export default SepCon.createComponent({
         }
     },
     view: {
-        'render'() {
-            let indexOptions = [];
-            for (let i = 0, e = this.props.indexes.length; i < e; i++) {
-                indexOptions[i] = {
-                    value: this.props.indexes[i],
-                    label: this.props.indexes[i],
-                };
-            }
-            const select = Select.createTag()
-                .props({
-                    name: 'changeIndex',
-                    options: indexOptions,
-                    selected: this.props.selected,
-                })
-                .refMethods({
-                    onchange: 'setNewIndex',
-                });
+        lifecycle: {
+            on: {
+                render() {
+                    let indexOptions = [];
+                    for (let i = 0, e = this.props.indexes.length; i < e; i++) {
+                        indexOptions[i] = {
+                            value: this.props.indexes[i],
+                            label: this.props.indexes[i],
+                        };
+                    }
+                    const select = Select.createTag()
+                        .props({
+                            name: 'changeIndex',
+                            options: indexOptions,
+                            selected: this.props.selected,
+                        })
+                        .refMethods({
+                            onchange: 'setNewIndex',
+                        });
 
-            const text = TextInput.createTag()
-                .props({
-                    name: 'changeNumber',
-                    value: this.props.value,
-                })
-                .refMethods({
-                    onchange: 'setNewValue',
-                    onfocus: 'textIsFocused',
-                    onblur: 'textIsNotFocused',
-                });
+                    const text = TextInput.createTag()
+                        .props({
+                            name: 'changeNumber',
+                            value: this.props.value,
+                        })
+                        .refMethods({
+                            onchange: 'setNewValue',
+                            onfocus: 'textIsFocused',
+                            onblur: 'textIsNotFocused',
+                        });
 
-            const button = DescribedButton.createTag()
-                .props({
-                    label: 'Reset Number ' + this.props.selected,
-                })
-                .refMethods({
-                    onclick: 'resetNumber',
-                });
+                    const button = DescribedButton.createTag()
+                        .props({
+                            label: 'Reset Number ' + this.props.selected,
+                        })
+                        .refMethods({
+                            onclick: 'resetNumber',
+                        });
 
-            return `
+                    return `
                     <div class="sepcon sepcon-component">
                         ${select.render()}
                         ${text.render()}
                         ${button.render()}
                     </div>`;
-        },
-        'post:render'(changed) {
-            if (changed && changed.selected) {
-                this.element.querySelector('input[name="changeNumber"]').focus();
+                }
+            },
+            post: {
+                render(changed) {
+                    if (changed && changed.selected) {
+                        this.element.querySelector('input[name="changeNumber"]').focus();
+                    }
+                }
             }
         }
     }

--- a/test-example-app/components/props-passer.js
+++ b/test-example-app/components/props-passer.js
@@ -23,29 +23,32 @@ const OneStepPass = SepCon.createComponent({
                 }
             }
         },
-        change() {
-            return false;
+        lifecycle: {
+            change() {
+                return false;
+            }
         }
     },
     view: {
-        render() {
-            const button = DescribedButton.createTag()
-                .props({label: 'Change'})
-                .refMethods({onclick: 'onclick1'});
+        lifecycle: {
+            render() {
+                const button = DescribedButton.createTag()
+                    .props({label: 'Change'})
+                    .refMethods({onclick: 'onclick1'});
 
-            let button2 = null;
+                let button2 = null;
 
-            const text = TextHolder.createTag()
-                .props({value: 'Current scope (static value): ' + this.props['one-step-value']});
-            const textHolder = TextHolder.createTag()
-                .refProps({value: 'one-step-value'});
+                const text = TextHolder.createTag()
+                    .props({value: 'Current scope (static value): ' + this.props['one-step-value']});
+                const textHolder = TextHolder.createTag()
+                    .refProps({value: 'one-step-value'});
 
-            if (this.methods.onclickCb) {
-                button2 = DescribedButton.createTag()
-                    .props({label: 'Trigger Anonymous Function'})
-                    .refMethods({onclick: 'onclickCb'});
-            }
-            return `<div class="sepcon sepcon-element flex-container">
+                if (this.methods.onclickCb) {
+                    button2 = DescribedButton.createTag()
+                        .props({label: 'Trigger Anonymous Function'})
+                        .refMethods({onclick: 'onclickCb'});
+                }
+                return `<div class="sepcon sepcon-element flex-container">
                     <div>
                         ${text.render()}
                     </div>
@@ -57,6 +60,7 @@ const OneStepPass = SepCon.createComponent({
                     </div>
                     ${ button2 ? '<div>' + button2.render() + '</div>' : '' }
                 </div>`;
+            }
         }
     }
 });
@@ -73,33 +77,37 @@ const TwoStepsPass = SepCon.createComponent({
                 },
             },
         },
-        change() {
-            return false;
+        lifecycle: {
+            change() {
+                return false;
+            }
         }
     },
     view: {
-        render() {
-            const text = TextHolder.createTag()
-                .props({value: 'Current scope (static value): ' + this.props['two-steps-value']});
-            const oneStepPass = OneStepPass.createTag()
-                .refProps({'one-step-value': 'two-steps-value'})
-                .refMethods({
-                    onclick1: 'onclick2',
-                    onclickCb: 'onclickCb'
-                });
+        lifecycle: {
+            render() {
+                const text = TextHolder.createTag()
+                    .props({value: 'Current scope (static value): ' + this.props['two-steps-value']});
+                const oneStepPass = OneStepPass.createTag()
+                    .refProps({'one-step-value': 'two-steps-value'})
+                    .refMethods({
+                        onclick1: 'onclick2',
+                        onclickCb: 'onclickCb'
+                    });
 
-            let button = null;
-            if (this.methods.onclickCb) {
-                button = DescribedButton.createTag()
-                    .props({label: 'Trigger Anonymous Function By Reference'})
-                    .refMethods({onclick: 'onclickCb'});
-            }
+                let button = null;
+                if (this.methods.onclickCb) {
+                    button = DescribedButton.createTag()
+                        .props({label: 'Trigger Anonymous Function By Reference'})
+                        .refMethods({onclick: 'onclickCb'});
+                }
 
-            return `<div class="sepcon sepcon-element flex-container">
+                return `<div class="sepcon sepcon-element flex-container">
                         <div>${text.render()}</div>
                         <div>${oneStepPass.render()}</div>
                         <div>${button ? button.render() : ''}</div>
                     </div>`;
+            }
         }
     }
 });
@@ -118,16 +126,18 @@ const ThreeStepsPass = SepCon.createComponent({
         }
     },
     view: {
-        render() {
-            const text = TextHolder.createTag()
-                .props({value: 'Current scope (\'change\' is enabled): ' + this.props['three-steps-value']});
-            const twoStepsPass = TwoStepsPass.createTag()
-                .refProps({'two-steps-value': 'three-steps-value'})
-                .refMethods({onclick2: 'onclick3'});
-            return `<div class="sepcon sepcon-element flex-container">
+        lifecycle: {
+            render() {
+                const text = TextHolder.createTag()
+                    .props({value: 'Current scope (\'change\' is enabled): ' + this.props['three-steps-value']});
+                const twoStepsPass = TwoStepsPass.createTag()
+                    .refProps({'two-steps-value': 'three-steps-value'})
+                    .refMethods({onclick2: 'onclick3'});
+                return `<div class="sepcon sepcon-element flex-container">
                     <div>${text.render()}</div>
                     <div>${twoStepsPass.render()}</div>
                 </div>`;
+            }
         }
     }
 });
@@ -146,45 +156,48 @@ export default SepCon.createComponent({
                 },
             }
         },
-        change() {
-            return false;
+        lifecycle: {
+            change() {
+                return false;
+            }
         }
     },
     view: {
-        'render'() {
-            const text = TextHolder.createTag()
-                .props({value: this.props.number});
+        lifecycle: {
+            render() {
+                const text = TextHolder.createTag()
+                    .props({value: this.props.number});
 
-            const textReference = TextHolder.createTag()
-                .refProps({value: 'number'});
+                const textReference = TextHolder.createTag()
+                    .refProps({value: 'number'});
 
-            const oneStepPass = OneStepPass.createTag()
-                .refProps({'one-step-value': 'number'})
-                .refMethods({onclick1: 'change'});
+                const oneStepPass = OneStepPass.createTag()
+                    .refProps({'one-step-value': 'number'})
+                    .refMethods({onclick1: 'change'});
 
-            const twoStepsPass = TwoStepsPass.createTag()
-                .refProps({'two-steps-value': 'number'})
-                .methods({
-                    onclickCb: function (res) {
-                        console.log('click anonymous function', this, res);
-                    }.bind(this)
-                })
-                .refMethods({
-                    onclick2: 'change'
-                });
+                const twoStepsPass = TwoStepsPass.createTag()
+                    .refProps({'two-steps-value': 'number'})
+                    .methods({
+                        onclickCb: function (res) {
+                            console.log('click anonymous function', this, res);
+                        }.bind(this)
+                    })
+                    .refMethods({
+                        onclick2: 'change'
+                    });
 
 
-            const threeStepsPass = ThreeStepsPass.createTag()
-                .refProps({'three-steps-value': 'number'})
-                .refMethods({
-                    onclick3: 'change'
-                });
+                const threeStepsPass = ThreeStepsPass.createTag()
+                    .refProps({'three-steps-value': 'number'})
+                    .refMethods({
+                        onclick3: 'change'
+                    });
 
-            const button = DescribedButton.createTag()
-                .props({label: 'Change'})
-                .refMethods({onclick: 'change'});
+                const button = DescribedButton.createTag()
+                    .props({label: 'Change'})
+                    .refMethods({onclick: 'change'});
 
-            return `<div class="sepcon sepcon-component">
+                return `<div class="sepcon sepcon-component">
                     <h3>Original Number - External (static)</h3>
                     ${text.render()}
                     <h3>Original Number - Referenced</h3>
@@ -198,11 +211,12 @@ export default SepCon.createComponent({
                     <h3>Three-Steps Passed Number</h3>
                     ${threeStepsPass.render()}
                 </div>`;
-        },
-        change(e) {
-            e.preventDefault();
-            e.stopPropagation();
-            this.methods.change();
+            },
+            change(e) {
+                e.preventDefault();
+                e.stopPropagation();
+                this.methods.change();
+            }
         }
     }
 });

--- a/test-example-app/containers/navbar.js
+++ b/test-example-app/containers/navbar.js
@@ -26,24 +26,26 @@ export default SepCon.createComponent({
         }
     },
     view: {
-        render() {
-            let buttons = [];
-            for (let key in this.props.pages) {
-                const page = this.props.pages[key];
-                buttons.push(Button.createTag()
-                    .props({
-                        label: page.title,
-                        isActive: this.props.currentPage.id === key
-                    })
-                    .methods({
-                        onclick: this.methods.navigate.bind(this, page.url)
-                    })
-                    .render());
-            }
-            return `
+        lifecycle: {
+            render() {
+                let buttons = [];
+                for (let key in this.props.pages) {
+                    const page = this.props.pages[key];
+                    buttons.push(Button.createTag()
+                        .props({
+                            label: page.title,
+                            isActive: this.props.currentPage.id === key
+                        })
+                        .methods({
+                            onclick: this.methods.navigate.bind(this, page.url)
+                        })
+                        .render());
+                }
+                return `
                     <div class="sepcon sepcon-container flex-container">
                         ${buttons.join('')}
                     </div>`;
+            }
         }
     }
 });

--- a/test-example-app/containers/numbers-container.js
+++ b/test-example-app/containers/numbers-container.js
@@ -7,10 +7,11 @@ export default SepCon.createComponent({
     id: 'numbers-container',
 }, {
     view: {
-        render() {
-            const oneNumberChanger = OneNumberChanger.createTag();
-            const numbersPresentor = NumbersPresentor.createTag();
-            return `<div class="sepcon sepcon-container flex-container">
+        lifecycle: {
+            render() {
+                const oneNumberChanger = OneNumberChanger.createTag();
+                const numbersPresentor = NumbersPresentor.createTag();
+                return `<div class="sepcon sepcon-container flex-container">
                     <div>
                         ${numbersPresentor.render()}
                     </div>
@@ -18,6 +19,7 @@ export default SepCon.createComponent({
                         ${oneNumberChanger.render()}
                     </div>
                 </div>`;
+            }
         }
     }
 });

--- a/test-example-app/containers/numbers-modifier-container.js
+++ b/test-example-app/containers/numbers-modifier-container.js
@@ -5,10 +5,12 @@ export default SepCon.createComponent({
     id: 'numbers-modifier-container',
 }, {
     view: {
-        render() {
-            return `<div class="sepcon sepcon-container">
+        lifecycle: {
+            render() {
+                return `<div class="sepcon sepcon-container">
                     ${Counter.createTag().render()}
                 </div>`;
+            }
         }
     }
 });

--- a/test-example-app/containers/passing-props-container.js
+++ b/test-example-app/containers/passing-props-container.js
@@ -5,13 +5,15 @@ export default SepCon.createComponent({
     id: 'passing-props-container',
 }, {
     view: {
-        render() {
-            const propsPasser = PropsPasser.createTag();
-            return `<div class="sepcon sepcon-container">
+        lifecycle: {
+            render() {
+                const propsPasser = PropsPasser.createTag();
+                return `<div class="sepcon sepcon-container">
                     <div class="presentors">
                         ${propsPasser.render()}
                     </div>
                 </div>`;
+            }
         }
     }
 });

--- a/test-example-app/elements/described-button.js
+++ b/test-example-app/elements/described-button.js
@@ -29,17 +29,19 @@ export default SepCon.createComponent({
         events: [
             {event: 'click', selector: '.clickable', callback: 'handleClick'}
         ],
-        'render'() {
-            let classes = ['button', 'raised', 'clickable'];
-            if (this.props.isActive) {
-                classes.push('is-active');
-            }
-            return `<div class="sepcon sepcon-element">
+        lifecycle: {
+            render() {
+                let classes = ['button', 'raised', 'clickable'];
+                if (this.props.isActive) {
+                    classes.push('is-active');
+                }
+                return `<div class="sepcon sepcon-element">
                 <div class="${classes.join(' ')}">
                     <h5>${this.props.label}</h5>
                 </div>
                 ${this.children.length ? this.children.map(el => el.outerHTML).join('') : ''}
             </div>`;
+            }
         },
         handleClick(e) {
             e.preventDefault();

--- a/test-example-app/elements/select.js
+++ b/test-example-app/elements/select.js
@@ -20,18 +20,20 @@ export default SepCon.createComponent({
         events: [
             {event: 'change', selector: 'select', callback: 'handleChange'}
         ],
-        'render'() {
-            let options = [];
-            for (let i = 0, e = this.props.options.length; i < e; i++) {
-                const option = this.props.options[i];
-                const isSelected = this.props.selected === option.value ? 'selected="selected"' : '';
-                options.push(`<option ${isSelected} value="${option.value}">${option.label}</option>`);
-            }
-            return `<div class="sepcon sepcon-element">
+        lifecycle: {
+            render() {
+                let options = [];
+                for (let i = 0, e = this.props.options.length; i < e; i++) {
+                    const option = this.props.options[i];
+                    const isSelected = this.props.selected === option.value ? 'selected="selected"' : '';
+                    options.push(`<option ${isSelected} value="${option.value}">${option.label}</option>`);
+                }
+                return `<div class="sepcon sepcon-element">
                     <select name="${this.props.name}">
                         ${options.join('')}
                     </select>
                 </div>`;
+            },
         },
         handleChange(e) {
             this.methods.onchange(e.target.value);

--- a/test-example-app/elements/text-holder.js
+++ b/test-example-app/elements/text-holder.js
@@ -9,10 +9,12 @@ export default SepCon.createComponent({
         }
     },
     view: {
-        render() {
-            return `<div class="sepcon sepcon-element">
+        lifecycle: {
+            render() {
+                return `<div class="sepcon sepcon-element">
                     ${this.props.value}
                 </div>`;
+            }
         }
     }
 });

--- a/test-example-app/elements/text-input.js
+++ b/test-example-app/elements/text-input.js
@@ -29,14 +29,16 @@ export default SepCon.createComponent({
                 }
             },
         },
-        mount() {
-            if (this.props.external.value) {
-                this.updateCurrentValueWithExternal();
-            }
-        },
-        change(changed) {
-            if (changed.value) {
-                this.updateCurrentValueWithExternal();
+        lifecycle: {
+            mount() {
+                if (this.props.external.value) {
+                    this.updateCurrentValueWithExternal();
+                }
+            },
+            change(changed) {
+                if (changed.value) {
+                    this.updateCurrentValueWithExternal();
+                }
             }
         },
         updateCurrentValueWithExternal() {
@@ -49,10 +51,12 @@ export default SepCon.createComponent({
             {event: 'focus', selector: 'input', callback: 'handleFocus'},
             {event: 'blur', selector: 'input', callback: 'handleBlur'},
         ],
-        render() {
-            return `<div class="sepcon sepcon-element">
+        lifecycle: {
+            render() {
+                return `<div class="sepcon sepcon-element">
                 <input name="${this.props.name}" value="${this.props.currentValue}"/>
             </div>`;
+            }
         },
         handleChange(e) {
             this.methods.onchange(e.target.value);

--- a/test-example-app/index.js
+++ b/test-example-app/index.js
@@ -28,8 +28,10 @@ SepCon.createModifier({
             }
         }
     ],
-    mount() {
-        console.log('mount modifier');
+    lifecycle: {
+        mount() {
+            console.log('mount modifier');
+        }
     }
 });
 

--- a/test-example-app/layouts/layout.js
+++ b/test-example-app/layouts/layout.js
@@ -19,31 +19,33 @@ export default SepCon.createComponent({
         }
     },
     view: {
-        render() {
-            if (!this.props.page) {
-                return false;
-            }
-            let header = Header.createTag();
-            let navbar = Navbar.createTag();
-            let html = '';
-            switch (this.props.page.id) {
-                case 'home':
-                    html = `<div class="sepcon sepcon-container">
+        lifecycle: {
+            render() {
+                if (!this.props.page) {
+                    return false;
+                }
+                let header = Header.createTag();
+                let navbar = Navbar.createTag();
+                let html = '';
+                switch (this.props.page.id) {
+                    case 'home':
+                        html = `<div class="sepcon sepcon-container">
                     ${NumbersModifierContainer.createTag().render()}
                 </div>`;
-                    break;
-                case 'flux':
-                    html = `<div class="sepcon sepcon-container">
+                        break;
+                    case 'flux':
+                        html = `<div class="sepcon sepcon-container">
                     ${NumbersContainer.createTag().render()}
                 </div>`;
-                    break;
-                case 'externals':
-                    html = `<div class="sepcon sepcon-container">
+                        break;
+                    case 'externals':
+                        html = `<div class="sepcon sepcon-container">
                     ${PassingPropsContainer.createTag().render()}
                 </div>`;
-                    break;
+                        break;
+                }
+                return `${header.render()}${navbar.render()}${html}`;
             }
-            return `${header.render()}${navbar.render()}${html}`;
         },
         descendantChange(component) {
             console.log('layout descendantChange', component);

--- a/test-example-app/modifiers/numbers.js
+++ b/test-example-app/modifiers/numbers.js
@@ -13,17 +13,19 @@ export default SepCon.createModifier({
             this.setProps('numbers', {numbers});
         },
     },
-    mount() {
-        setTimeout(()=> {
-            this.methods.init();
-            setTimeout(()=> {
-                //setInterval(()=>{
-                this.methods.updateOneNumber(1, Math.round(Math.random() * 1000));
-                //}, 100);
-                setTimeout(()=> {
-                    this.methods.updateOneNumber('B', Math.round(Math.random() * 1000));
-                }, 5000);
+    lifecycle: {
+        mount() {
+            setTimeout(() => {
+                this.methods.init();
+                setTimeout(() => {
+                    //setInterval(()=>{
+                    this.methods.updateOneNumber(1, Math.round(Math.random() * 1000));
+                    //}, 100);
+                    setTimeout(() => {
+                        this.methods.updateOneNumber('B', Math.round(Math.random() * 1000));
+                    }, 5000);
+                }, 500);
             }, 500);
-        }, 500);
+        }
     }
 });

--- a/test-example-app/modifiers/pages.js
+++ b/test-example-app/modifiers/pages.js
@@ -22,7 +22,9 @@ export default SepCon.createModifier({
             }
         }
     ],
-    mount() {
-        console.log('mount modifier');
+    lifecycle: {
+        mount() {
+            console.log('mount modifier');
+        }
     }
 });

--- a/test/component-instance-state.test.js
+++ b/test/component-instance-state.test.js
@@ -2,7 +2,7 @@ import SepCon from '../src/index';
 
 let expect = chai.expect;
 
-describe('Component Unit', ()=> {
+describe('Component Unit', () => {
     let testNum = 0;
     const scope = SepCon.createScope();
     beforeEach(function () {
@@ -13,10 +13,12 @@ describe('Component Unit', ()=> {
             id: 'test-' + testNum + '-child',
         }, {
             state: {
-                change(changed) {
-                    if (changed.check) {
-                        expect(changed.check.newValue).to.be.equal(1);
-                        done();
+                lifecycle: {
+                    change(changed) {
+                        if (changed.check) {
+                            expect(changed.check.newValue).to.be.equal(1);
+                            done();
+                        }
                     }
                 }
             }
@@ -30,19 +32,28 @@ describe('Component Unit', ()=> {
                         passedProp: 0
                     }
                 },
-                'post:mount'() {
-                    this.setProps({passedProp: this.props.local.passedProp + 1}, true);
+                lifecycle: {
+                    mount() {
+                        console.log('dfgdf');
+                    },
+                    change() {
+                        return false;
+                    },
+                    post: {
+                        mount() {
+                            this.setProps({passedProp: this.props.local.passedProp + 1}, true);
+                        }
+                    }
                 },
-                change() {
-                    return false;
-                }
             },
             view: {
-                render() {
-                    const childElement = child.createTag()
-                        .refProps({check: 'passedProp'});
-                    expect(this.props.passedProp).to.be.equal(0);
-                    return childElement.render();
+                lifecycle: {
+                    render() {
+                        const childElement = child.createTag()
+                            .refProps({check: 'passedProp'});
+                        expect(this.props.passedProp).to.be.equal(0);
+                        return childElement.render();
+                    }
                 }
             }
         });
@@ -56,10 +67,14 @@ describe('Component Unit', ()=> {
             id: 'test-' + testNum + '-child',
         }, {
             state: {
-                change(changed) {
-                    if (changed.check) {
-                        expect(changed.check.newValue).to.be.equal(1);
-                        done();
+                lifecycle: {
+                    on: {
+                        change(changed) {
+                            if (changed.check) {
+                                expect(changed.check.newValue).to.be.equal(1);
+                                done();
+                            }
+                        }
                     }
                 }
             }
@@ -75,22 +90,30 @@ describe('Component Unit', ()=> {
                         }
                     }
                 },
-                'post:mount'() {
-                    let mainObj = {
-                        passedProp: this.props.local.mainObj.passedProp + 1
-                    };
-                    this.setProps({mainObj}, true);
-                },
-                change() {
-                    return false;
+                lifecycle: {
+                    post: {
+                        mount() {
+                            let mainObj = {
+                                passedProp: this.props.local.mainObj.passedProp + 1
+                            };
+                            this.setProps({mainObj}, true);
+                        }
+                    },
+                    on: {
+                        change() {
+                            return false;
+                        }
+                    }
                 }
             },
             view: {
-                render() {
-                    const childElement = child.createTag()
-                        .refProps({check: 'mainObj.passedProp'});
-                    expect(this.props.mainObj.passedProp).to.be.equal(0);
-                    return childElement.render();
+                lifecycle: {
+                    render() {
+                        const childElement = child.createTag()
+                            .refProps({check: 'mainObj.passedProp'});
+                        expect(this.props.mainObj.passedProp).to.be.equal(0);
+                        return childElement.render();
+                    }
                 }
             }
         });
@@ -104,11 +127,13 @@ describe('Component Unit', ()=> {
             id: 'test-' + testNum + '-child',
         }, {
             state: {
-                change(changed) {
-                    if (changed.checkChild1) {
-                        expect(changed.checkChild1.newValue).to.be.equal(1);
-                        expect(changed.checkChild2.newValue).to.be.equal('b');
-                        done();
+                lifecycle: {
+                    change(changed) {
+                        if (changed.checkChild1) {
+                            expect(changed.checkChild1.newValue).to.be.equal(1);
+                            expect(changed.checkChild2.newValue).to.be.equal('b');
+                            done();
+                        }
                     }
                 }
             }
@@ -117,22 +142,26 @@ describe('Component Unit', ()=> {
             id: 'test-' + testNum + '-parent',
         }, {
             state: {
-                change(changed) {
-                    if (changed.checkParent1) {
-                        expect(changed.checkParent1.newValue).to.be.equal(1);
-                        expect(changed.checkParent2.newValue).to.be.equal('b');
-                        //done();
+                lifecycle: {
+                    change(changed) {
+                        if (changed.checkParent1) {
+                            expect(changed.checkParent1.newValue).to.be.equal(1);
+                            expect(changed.checkParent2.newValue).to.be.equal('b');
+                            //done();
+                        }
                     }
                 }
             },
             view: {
-                render() {
-                    const childElement = child.createTag()
-                        .refProps({
-                            checkChild1: 'checkParent1',
-                            checkChild2: 'checkParent2'
-                        });
-                    return childElement.render();
+                lifecycle: {
+                    render() {
+                        const childElement = child.createTag()
+                            .refProps({
+                                checkChild1: 'checkParent1',
+                                checkChild2: 'checkParent2'
+                            });
+                        return childElement.render();
+                    }
                 }
             }
         });
@@ -148,29 +177,39 @@ describe('Component Unit', ()=> {
                         mainProp: 'a'
                     }
                 },
-                'post:mount'() {
-                    let mainObj = {
-                        passedProp: this.props.local.mainObj.passedProp + 1
-                    };
-                    this.setProps({
-                        mainObj,
-                        mainProp: 'b'
-                    }, true);
+                lifecycle: {
+                    on: {
+                        change() {
+                            return false;
+                        }
+                    },
+                    post: {
+                        mount() {
+                            let mainObj = {
+                                passedProp: this.props.local.mainObj.passedProp + 1
+                            };
+                            this.setProps({
+                                mainObj,
+                                mainProp: 'b'
+                            }, true);
+                        }
+                    }
                 },
-                change() {
-                    return false;
-                }
+
+
             },
             view: {
-                render() {
-                    const parentElement = parent.createTag()
-                        .refProps({
-                            checkParent1: 'mainObj.passedProp',
-                            checkParent2: 'mainProp'
-                        });
-                    expect(this.props.mainObj.passedProp).to.be.equal(0);
-                    expect(this.props.mainProp).to.be.equal('a');
-                    return parentElement.render();
+                lifecycle: {
+                    render() {
+                        const parentElement = parent.createTag()
+                            .refProps({
+                                checkParent1: 'mainObj.passedProp',
+                                checkParent2: 'mainProp'
+                            });
+                        expect(this.props.mainObj.passedProp).to.be.equal(0);
+                        expect(this.props.mainProp).to.be.equal('a');
+                        return parentElement.render();
+                    }
                 }
             }
         });
@@ -184,9 +223,11 @@ describe('Component Unit', ()=> {
             id: 'test-' + testNum + '-child',
         }, {
             state: {
-                mount() {
-                    expect(this.props.external.check).to.be.equal(1);
-                    done();
+                lifecycle: {
+                    mount() {
+                        expect(this.props.external.check).to.be.equal(1);
+                        done();
+                    }
                 }
             }
         });
@@ -194,11 +235,13 @@ describe('Component Unit', ()=> {
             id: 'test-' + testNum + '-parent',
         }, {
             view: {
-                render() {
-                    const childElement = child.createTag()
-                        .refProps({check: 'passedProp'});
-                    expect(this.props.passedProp).to.be.equal(1);
-                    return childElement.render();
+                lifecycle: {
+                    render() {
+                        const childElement = child.createTag()
+                            .refProps({check: 'passedProp'});
+                        expect(this.props.passedProp).to.be.equal(1);
+                        return childElement.render();
+                    }
                 }
             }
         });
@@ -212,8 +255,12 @@ describe('Component Unit', ()=> {
             id: 'test-' + testNum + '-child',
         }, {
             view: {
-                render() {
-                    this.methods.executeCb();
+                lifecycle: {
+                    on: {
+                        render() {
+                            this.methods.executeCb();
+                        }
+                    }
                 }
             }
         });
@@ -221,12 +268,14 @@ describe('Component Unit', ()=> {
             id: 'test-' + testNum + '-parent',
         }, {
             view: {
-                render() {
-                    const childElement = child.createTag()
-                        .methods({
-                            executeCb: done
-                        });
-                    return childElement.render();
+                lifecycle: {
+                    render() {
+                        const childElement = child.createTag()
+                            .methods({
+                                executeCb: done
+                            });
+                        return childElement.render();
+                    }
                 }
             }
         });
@@ -240,8 +289,10 @@ describe('Component Unit', ()=> {
             id: 'test-' + testNum + '-child',
         }, {
             view: {
-                render() {
-                    this.methods.executeCb();
+                lifecycle: {
+                    render() {
+                        this.methods.executeCb();
+                    }
                 }
             }
         });
@@ -258,12 +309,14 @@ describe('Component Unit', ()=> {
                 }
             },
             view: {
-                render() {
-                    const childElement = child.createTag()
-                        .refMethods({
-                            executeCb: 'executeMe'
-                        });
-                    return childElement.render();
+                lifecycle: {
+                    render() {
+                        const childElement = child.createTag()
+                            .refMethods({
+                                executeCb: 'executeMe'
+                            });
+                        return childElement.render();
+                    }
                 }
             }
         });
@@ -288,8 +341,10 @@ describe('Component Unit', ()=> {
                 }
             },
             view: {
-                render() {
-                    this.methods.executeCb();
+                lifecycle: {
+                    render() {
+                        this.methods.executeCb();
+                    }
                 }
             }
         });
@@ -307,12 +362,14 @@ describe('Component Unit', ()=> {
                 }
             },
             view: {
-                render() {
-                    const childElement = child.createTag()
-                        .refMethods({
-                            executeCb: 'executeMe'
-                        });
-                    return childElement.render();
+                lifecycle: {
+                    render() {
+                        const childElement = child.createTag()
+                            .refMethods({
+                                executeCb: 'executeMe'
+                            });
+                        return childElement.render();
+                    }
                 }
             }
         });
@@ -332,16 +389,20 @@ describe('Component Unit', ()=> {
                         prop: 1
                     }
                 },
-                mount() {
-                    this.setProps({prop: 2});
+                lifecycle: {
+                    mount() {
+                        this.setProps({prop: 2});
+                    }
                 }
             },
             view: {
-                render(changed) {
-                    if (changed && changed.prop) {
-                        console.log('123');
-                        expect(this.props.prop).to.be.equal(2);
-                        done();
+                lifecycle: {
+                    render(changed) {
+                        if (changed && changed.prop) {
+                            console.log('123');
+                            expect(this.props.prop).to.be.equal(2);
+                            done();
+                        }
                     }
                 }
             }

--- a/test/component.extend.test.js
+++ b/test/component.extend.test.js
@@ -50,16 +50,20 @@ describe('Component Extension', ()=> {
                     }
                 }
             },
-            mount() {
-                this.setProps({
-                    number: Math.round(Math.random() * 1000),
-                    text: parseInt(Date.now() * 1000 + Math.round(Math.random() * 1000)).toString(36)
-                }, true);
+            lifecycle: {
+                mount() {
+                    this.setProps({
+                        number: Math.round(Math.random() * 1000),
+                        text: parseInt(Date.now() * 1000 + Math.round(Math.random() * 1000)).toString(36)
+                    }, true);
+                }
             }
         },
         view: {
-            render() {
-                return `${this.props.text} ${this.props.number} ${this.props.num}<br />`;
+            lifecycle: {
+                render() {
+                    return `${this.props.text} ${this.props.number} ${this.props.num}<br />`;
+                }
             }
         }
     });
@@ -81,14 +85,16 @@ describe('Component Extension', ()=> {
                 }
             },
             view: {
-                render() {
-                    expect(this.props).to.have.property('number');
-                    expect(this.props).to.have.property('text');
-                    expect(this.props).to.have.property('array');
-                    expect(this.props).to.have.property('num');
-                    expect(this.props.num).to.be.equal(5);
-                    this.methods.done();
-                    return `${JSON.stringify(this.props)}`;
+                lifecycle: {
+                    render() {
+                        expect(this.props).to.have.property('number');
+                        expect(this.props).to.have.property('text');
+                        expect(this.props).to.have.property('array');
+                        expect(this.props).to.have.property('num');
+                        expect(this.props.num).to.be.equal(5);
+                        this.methods.done();
+                        return `${JSON.stringify(this.props)}`;
+                    }
                 }
             }
         });
@@ -112,21 +118,25 @@ describe('Component Extension', ()=> {
                         array: []
                     }
                 },
-                mount() {
-                    expect(parent.proto.state).to.have.property('mount');
-                    expect(parent.proto.state.methods.local).to.have.property('printNumber');
-                    expect(parent.proto.state.methods.local).to.have.property('printText');
-                    parent.proto.state.mount.apply(this, arguments);
+                lifecycle: {
+                    mount() {
+                        expect(parent.proto.state.lifecycle).to.have.property('mount');
+                        expect(parent.proto.state.methods.local).to.have.property('printNumber');
+                        expect(parent.proto.state.methods.local).to.have.property('printText');
+                        parent.proto.state.lifecycle.mount.apply(this, arguments);
+                    }
                 }
             },
             view: {
-                render() {
-                    expect(parent.proto).to.be.an('object');
-                    expect(parent.proto).to.have.property('view');
-                    expect(parent.proto.view).to.have.property('render');
-                    expect(parent.proto.view.render).to.not.equal(this.render);
-                    this.methods.done();
-                    return `${this.props.array.length} ${parent.proto.view.render.apply(this, arguments)}`;
+                lifecycle: {
+                    render() {
+                        expect(parent.proto).to.be.an('object');
+                        expect(parent.proto).to.have.property('view');
+                        expect(parent.proto.view.lifecycle).to.have.property('render');
+                        expect(parent.proto.view.lifecycle.render).to.not.equal(this.render);
+                        this.methods.done();
+                        return `${this.props.array.length} ${parent.proto.view.lifecycle.render.apply(this, arguments)}`;
+                    }
                 }
             }
         });
@@ -152,18 +162,22 @@ describe('Component Extension', ()=> {
                         }
                     }
                 },
-                mount() {
-                    this.setProps({
-                        text: 'Hello',
-                        number: 15
-                    }, true);
+                lifecycle: {
+                    mount() {
+                        this.setProps({
+                            text: 'Hello',
+                            number: 15
+                        }, true);
+                    }
                 }
             },
             view: {
-                render() {
-                    expect(this.methods.printText()).to.be.equal('Hello');
-                    expect(this.methods.printNumber()).to.be.equal(15);
-                    this.methods.done();
+                lifecycle: {
+                    render() {
+                        expect(this.methods.printText()).to.be.equal('Hello');
+                        expect(this.methods.printNumber()).to.be.equal(15);
+                        this.methods.done();
+                    }
                 }
             }
         });
@@ -204,18 +218,22 @@ describe('Component Extension', ()=> {
                         }
                     }
                 },
-                mount() {
-                    this.setProps({
-                        text: 'Hello',
-                        number: 15
-                    }, true);
+                lifecycle: {
+                    mount() {
+                        this.setProps({
+                            text: 'Hello',
+                            number: 15
+                        }, true);
+                    }
                 }
             },
             view: {
-                render() {
-                    expect(this.methods.printText()).to.be.equal('Hello');
-                    expect(this.methods.printNumber()).to.be.equal(15);
-                    this.methods.done();
+                lifecycle: {
+                    render() {
+                        expect(this.methods.printText()).to.be.equal('Hello');
+                        expect(this.methods.printNumber()).to.be.equal(15);
+                        this.methods.done();
+                    }
                 }
             }
         });

--- a/test/component.global.test.js
+++ b/test/component.global.test.js
@@ -83,28 +83,30 @@ describe('Component Global Segregation (+ Data & Modifier)', ()=> {
                         }
                     }
                 },
-                mount() {
-                    this.methods.global.set();
-                },
-                change(changed) {
-                    expect(changed).to.have.property('objProp1');
-                    expect(changed.objProp1).to.have.property('oldValue');
-                    expect(changed.objProp1).to.have.property('newValue');
-                    expect(changed.objProp1.oldValue).to.be.equal(1);
-                    expect(changed.objProp1.newValue).to.be.equal(5);
+                lifecycle: {
+                    mount() {
+                        this.methods.global.set();
+                    },
+                    change(changed) {
+                        expect(changed).to.have.property('objProp1');
+                        expect(changed.objProp1).to.have.property('oldValue');
+                        expect(changed.objProp1).to.have.property('newValue');
+                        expect(changed.objProp1.oldValue).to.be.equal(1);
+                        expect(changed.objProp1.newValue).to.be.equal(5);
 
-                    expect(changed).to.have.property('arrProp1');
-                    expect(changed.arrProp1).to.have.property('oldValue');
-                    expect(changed.arrProp1).to.have.property('newValue');
-                    expect(changed.arrProp1.oldValue).to.be.equal(1);
-                    expect(changed.arrProp1.newValue).to.have.property('prop1');
-                    expect(changed.arrProp1.newValue).to.have.property('prop2');
-                    expect(changed.arrProp1.newValue).to.have.property('prop3');
-                    expect(changed.arrProp1.newValue.prop1).to.be.equal(1);
-                    expect(changed.arrProp1.newValue.prop2).to.be.equal(2);
-                    expect(changed.arrProp1.newValue.prop3).to.be.equal(3);
+                        expect(changed).to.have.property('arrProp1');
+                        expect(changed.arrProp1).to.have.property('oldValue');
+                        expect(changed.arrProp1).to.have.property('newValue');
+                        expect(changed.arrProp1.oldValue).to.be.equal(1);
+                        expect(changed.arrProp1.newValue).to.have.property('prop1');
+                        expect(changed.arrProp1.newValue).to.have.property('prop2');
+                        expect(changed.arrProp1.newValue).to.have.property('prop3');
+                        expect(changed.arrProp1.newValue.prop1).to.be.equal(1);
+                        expect(changed.arrProp1.newValue.prop2).to.be.equal(2);
+                        expect(changed.arrProp1.newValue.prop3).to.be.equal(3);
 
-                    done();
+                        done();
+                    }
                 }
             }
         });
@@ -126,17 +128,19 @@ describe('Component Global Segregation (+ Data & Modifier)', ()=> {
                         }
                     }
                 },
-                mount() {
-                    this.methods.global.set();
-                },
-                change(changed) {
-                    expect(changed).to.have.property('objProp1');
-                    expect(changed.objProp1).to.have.property('oldValue');
-                    expect(changed.objProp1).to.have.property('newValue');
-                    expect(changed.objProp1.oldValue).to.be.equal(1);
-                    expect(changed.objProp1.newValue).to.be.equal(5);
+                lifecycle: {
+                    mount() {
+                        this.methods.global.set();
+                    },
+                    change(changed) {
+                        expect(changed).to.have.property('objProp1');
+                        expect(changed.objProp1).to.have.property('oldValue');
+                        expect(changed.objProp1).to.have.property('newValue');
+                        expect(changed.objProp1.oldValue).to.be.equal(1);
+                        expect(changed.objProp1.newValue).to.be.equal(5);
 
-                    done();
+                        done();
+                    }
                 }
             }
         });
@@ -152,16 +156,20 @@ describe('Component Global Segregation (+ Data & Modifier)', ()=> {
                         }
                     }
                 },
-                change() {
-                    return false;
+                lifecycle: {
+                    change() {
+                        return false;
+                    }
                 }
             },
             view: {
-                render() {
-                    return childComp.createTag()
-                        .refProps({
-                            objProp1: 'objProp1' + '.prop1'
-                        }).render();
+                lifecycle: {
+                    render() {
+                        return childComp.createTag()
+                            .refProps({
+                                objProp1: 'objProp1' + '.prop1'
+                            }).render();
+                    }
                 }
             }
         });
@@ -185,17 +193,19 @@ describe('Component Global Segregation (+ Data & Modifier)', ()=> {
                         }
                     }
                 },
-                mount() {
-                    this.methods.global.set();
-                },
-                change(changed) {
-                    expect(changed).to.have.property('objProp1');
-                    expect(changed.objProp1).to.have.property('oldValue');
-                    expect(changed.objProp1).to.have.property('newValue');
-                    expect(changed.objProp1.oldValue).to.be.equal(1);
-                    expect(changed.objProp1.newValue).to.be.equal(5);
+                lifecycle: {
+                    mount() {
+                        this.methods.global.set();
+                    },
+                    change(changed) {
+                        expect(changed).to.have.property('objProp1');
+                        expect(changed.objProp1).to.have.property('oldValue');
+                        expect(changed.objProp1).to.have.property('newValue');
+                        expect(changed.objProp1.oldValue).to.be.equal(1);
+                        expect(changed.objProp1.newValue).to.be.equal(5);
 
-                    done();
+                        done();
+                    }
                 }
             }
         });
@@ -203,16 +213,20 @@ describe('Component Global Segregation (+ Data & Modifier)', ()=> {
             id: 'child' + testNum,
         }, {
             state: {
-                change() {
-                    return false;
+                lifecycle: {
+                    change() {
+                        return false;
+                    }
                 }
             },
             view: {
-                render() {
-                    return grandChildComp.createTag()
-                        .refProps({
-                            objProp1: 'objProp1' + '.prop1'
-                        }).render();
+                lifecycle: {
+                    render() {
+                        return grandChildComp.createTag()
+                            .refProps({
+                                objProp1: 'objProp1' + '.prop1'
+                            }).render();
+                    }
                 }
             }
         });
@@ -228,16 +242,20 @@ describe('Component Global Segregation (+ Data & Modifier)', ()=> {
                         }
                     }
                 },
-                change() {
-                    return false;
+                lifecycle: {
+                    change() {
+                        return false;
+                    }
                 }
             },
             view: {
-                render() {
-                    return childComp.createTag()
-                        .refProps({
-                            objProp1: 'objProp1' + '.object'
-                        }).render();
+                lifecycle: {
+                    render() {
+                        return childComp.createTag()
+                            .refProps({
+                                objProp1: 'objProp1' + '.object'
+                            }).render();
+                    }
                 }
             }
         });
@@ -272,23 +290,25 @@ describe('Component Global Segregation (+ Data & Modifier)', ()=> {
                         }
                     }
                 },
-                mount() {
-                    this.setGlobalProps({
-                        test1: {
-                            data: 'globalProps',
-                            key: 'object'
-                        }
-                    });
-                    this.methods.global.change();
-                },
-                change(changed) {
-                    console.log(changed);
-                    expect(changed).to.have.property('test1');
-                    expect(changed).to.have.property('test2');
-                    expect(changed.test1.newValue).to.have.property('prop3');
-                    expect(changed.test1.newValue).to.have.property('object');
-                    expect(changed.test2.newValue).to.be.equal(1);
-                    done();
+                lifecycle: {
+                    mount() {
+                        this.setGlobalProps({
+                            test1: {
+                                data: 'globalProps',
+                                key: 'object'
+                            }
+                        });
+                        this.methods.global.change();
+                    },
+                    change(changed) {
+                        console.log(changed);
+                        expect(changed).to.have.property('test1');
+                        expect(changed).to.have.property('test2');
+                        expect(changed.test1.newValue).to.have.property('prop3');
+                        expect(changed.test1.newValue).to.have.property('object');
+                        expect(changed.test2.newValue).to.be.equal(1);
+                        done();
+                    }
                 }
             }
         });
@@ -315,23 +335,25 @@ describe('Component Global Segregation (+ Data & Modifier)', ()=> {
                         }
                     }
                 },
-                mount() {
-                    this.setGlobalMethods({
-                        change: {
-                            modifier: 'globalMethods',
-                            key: 'setMainObject'
-                        }
-                    });
-                    this.methods.global.change();
-                },
-                change(changed) {
-                    console.log(changed);
-                    expect(changed).to.have.property('test1');
-                    expect(changed).to.have.property('test2');
-                    expect(changed.test1.newValue).to.have.property('prop3');
-                    expect(changed.test1.newValue).to.have.property('object');
-                    expect(changed.test2.newValue).to.be.equal(1);
-                    done();
+                lifecycle: {
+                    mount() {
+                        this.setGlobalMethods({
+                            change: {
+                                modifier: 'globalMethods',
+                                key: 'setMainObject'
+                            }
+                        });
+                        this.methods.global.change();
+                    },
+                    change(changed) {
+                        console.log(changed);
+                        expect(changed).to.have.property('test1');
+                        expect(changed).to.have.property('test2');
+                        expect(changed.test1.newValue).to.have.property('prop3');
+                        expect(changed.test1.newValue).to.have.property('object');
+                        expect(changed.test2.newValue).to.be.equal(1);
+                        done();
+                    }
                 }
             }
         });

--- a/test/component.integration.test.js
+++ b/test/component.integration.test.js
@@ -10,8 +10,12 @@ describe('Component Integration', ()=>{
         },
         {
             view: {
-                render: function () {
-                    return '<div>Test</div>';
+                lifecycle: {
+                    on: {
+                        render: function () {
+                            return '<div>Test</div>';
+                        }
+                    }
                 }
             }
         }

--- a/test/data.extend.test.js
+++ b/test/data.extend.test.js
@@ -60,10 +60,12 @@ describe('Data Extension', ()=> {
                 }
             },
             view: {
-                render() {
-                    expect(this.props.num).to.be.equal(5);
-                    expect(this.props.txt).to.be.equal('hello');
-                    done();
+                lifecycle: {
+                    render() {
+                        expect(this.props.num).to.be.equal(5);
+                        expect(this.props.txt).to.be.equal('hello');
+                        done();
+                    }
                 }
             }
         });

--- a/test/modifier.extend.test.js
+++ b/test/modifier.extend.test.js
@@ -57,8 +57,10 @@ describe('Modifier Extension', ()=> {
                         }
                     }
                 },
-                mount() {
-                    this.methods.global.updateNum();
+                lifecycle: {
+                    mount() {
+                        this.methods.global.updateNum();
+                    }
                 }
             }
         });
@@ -116,9 +118,11 @@ describe('Modifier Extension', ()=> {
                         }
                     }
                 },
-                mount() {
-                    this.methods.global.setNum();
-                    this.methods.global.resetNum();
+                lifecycle: {
+                    mount() {
+                        this.methods.global.setNum();
+                        this.methods.global.resetNum();
+                    }
                 }
             }
         });

--- a/test/modifier.props.test.js
+++ b/test/modifier.props.test.js
@@ -63,15 +63,17 @@ describe('Modifier Properties', ()=> {
                     key: 'number'
                 }
             },
-            change(changed) {
-                expect(changed).to.have.property('globals2number');
-                expect(changed.globals2number.newValue).to.be.equal(7);
-                expect(changed.globals2number.oldValue).to.be.equal(5);
-                done();
-            },
-            mount() {
-                //this.modify('globals', 'updateNumber', 7);
-                scope.modifier('globals').updateNumber(7);
+            lifecycle: {
+                change(changed) {
+                    expect(changed).to.have.property('globals2number');
+                    expect(changed.globals2number.newValue).to.be.equal(7);
+                    expect(changed.globals2number.oldValue).to.be.equal(5);
+                    done();
+                },
+                mount() {
+                    //this.modify('globals', 'updateNumber', 7);
+                    scope.modifier('globals').updateNumber(7);
+                }
             }
         });
     });
@@ -90,15 +92,17 @@ describe('Modifier Properties', ()=> {
                     key: 'number'
                 }
             },
-            change(changed) {
-                expect(changed).to.have.property('globals_number');
-                expect(changed).to.have.property('globals2_number');
-                expect(changed.globals_number.newValue).to.be.equal(1);
-                expect(changed.globals2_number.newValue).to.be.equal(1);
-                done();
-            },
-            mount() {
-                scope.modifier('globals').updateTwoDatas();
+            lifecycle: {
+                change(changed) {
+                    expect(changed).to.have.property('globals_number');
+                    expect(changed).to.have.property('globals2_number');
+                    expect(changed.globals_number.newValue).to.be.equal(1);
+                    expect(changed.globals2_number.newValue).to.be.equal(1);
+                    done();
+                },
+                mount() {
+                    scope.modifier('globals').updateTwoDatas();
+                }
             }
         });
     });

--- a/test/performance.test.js
+++ b/test/performance.test.js
@@ -58,22 +58,31 @@ describe('Component Performance', ()=> {
                     }
                 }
             },
-            mount() {
-                this.setProps({
-                    number: Math.round(Math.random() * 1000),
-                    text: parseInt(Date.now() * 1000 + Math.round(Math.random() * 1000)).toString(36)
-                }, true);
+            lifecycle: {
+                on: {
+                    mount() {
+                        this.setProps({
+                            number: Math.round(Math.random() * 1000),
+                            text: parseInt(Date.now() * 1000 + Math.round(Math.random() * 1000)).toString(36)
+                        }, true);
+                    },
+                    change() {
+                        this.methods.external.changeCb();
+                    }
+                },
+                post: {
+                    mount() {
+                        this.methods.external.firstRenderCb();
+
+                    }
+                }
             },
-            'post:mount'() {
-                this.methods.external.firstRenderCb();
-            },
-            change() {
-                this.methods.external.changeCb();
-            }
         },
         view: {
-            render() {
-                return `${this.props.text} ${this.props.number} ${this.props.num}<br />`;
+            lifecycle: {
+                render() {
+                    return `${this.props.text} ${this.props.number} ${this.props.num}<br />`;
+                }
             }
         }
     });
@@ -96,26 +105,30 @@ describe('Component Performance', ()=> {
                     }
                 }
             },
-            change() {
-                return false;
+            lifecycle: {
+                change() {
+                    return false;
+                }
             }
         },
         view: {
-            render() {
-                const max = 1000;
-                let rows = [];
-                for (let i = 0; i < max; i++) {
-                    const current = row.createTag();
-                    current.id(i);
-                    if (i === max - 1) {
-                        current
-                            .refMethods({
-                                firstRenderCb: 'createDone'
-                            });
+            lifecycle: {
+                render() {
+                    const max = 1000;
+                    let rows = [];
+                    for (let i = 0; i < max; i++) {
+                        const current = row.createTag();
+                        current.id(i);
+                        if (i === max - 1) {
+                            current
+                                .refMethods({
+                                    firstRenderCb: 'createDone'
+                                });
+                        }
+                        rows.push(current.render());
                     }
-                    rows.push(current.render());
+                    return rows.join('');
                 }
-                return rows.join('');
             }
         }
     });

--- a/test/service.lifecycle.test.js
+++ b/test/service.lifecycle.test.js
@@ -19,17 +19,25 @@ describe('Service Lifecycle', () => {
                 testArgs(resolve, reject) {
                 }
             },
-            'pre:request'() {
-                expect(count).to.be.equal(0);
-                count++;
-            },
-            request() {
-                expect(count).to.be.equal(1);
-                count++;
-            },
-            'post:request'() {
-                expect(count).to.be.equal(2);
-                done();
+            lifecycle: {
+                pre: {
+                    request() {
+                        expect(count).to.be.equal(0);
+                        count++;
+                    }
+                },
+                on: {
+                    request() {
+                        expect(count).to.be.equal(1);
+                        count++;
+                    }
+                },
+                post: {
+                    request() {
+                        expect(count).to.be.equal(2);
+                        done();
+                    }
+                }
             }
         });
 
@@ -43,11 +51,13 @@ describe('Service Lifecycle', () => {
                 someRequest(resolve, reject) {
                 }
             },
-            'pre:request'(name, args) {
-                expect(name).to.be.equal('someRequest');
-                expect(args).to.be.an('array');
-                expect(args[0]).to.be.equal(5);
-                done();
+            lifecycle: {
+                request(name, args) {
+                    expect(name).to.be.equal('someRequest');
+                    expect(args).to.be.an('array');
+                    expect(args[0]).to.be.equal(5);
+                    done();
+                }
             }
         });
         scope.service('test' + testNum).requests.someRequest(5);
@@ -69,10 +79,14 @@ describe('Service Lifecycle', () => {
                     resolve('ok don\'t hurt me');
                 }
             },
-            'pre:request'(name) {
-                wentThroughLifecycle = true;
-                if (name === 'giveMeNow') {
-                    return false;
+            lifecycle: {
+                pre: {
+                    request(name) {
+                        wentThroughLifecycle = true;
+                        if (name === 'giveMeNow') {
+                            return false;
+                        }
+                    }
                 }
             }
         });
@@ -94,9 +108,13 @@ describe('Service Lifecycle', () => {
                     this.channels.testArgs();
                 }
             },
-            'pre:channel'() {
-                setTimeout(() => isOk && done(), 100);
-                return false;
+            lifecycle: {
+                pre: {
+                    channel() {
+                        setTimeout(() => isOk && done(), 100);
+                        return false;
+                    }
+                }
             }
         });
 

--- a/test/service.requests.test.js
+++ b/test/service.requests.test.js
@@ -8,8 +8,10 @@ describe('Service Requests', ()=> {
     scope.createProvider({
         id: 'testProvider',
     }, {
-        mount() {
-            console.log('mount provider');
+        lifecycle: {
+            mount() {
+                console.log('mount provider');
+            }
         }
     });
 
@@ -85,8 +87,13 @@ describe('Service Requests', ()=> {
         scope.createProvider({
             id: 'testProvider' + testNum,
         }, {
-            'pre:mount'() {
-                this.someProp = 100;
+            lifecycle: {
+                pre: {
+                    mount() {
+                        this.someProp = 100;
+
+                    }
+                }
             }
         });
         scope.createService({


### PR DESCRIPTION
Example:
```
SepCon.createComponent({id:'...'}, {
  state: {
    lifecycle: {
      pre: {
        mount() {...},
        change() {...}
      },
      on: {
        attach() {...},
        change() {...}
      },
      post: {
        change() {...}
      }
    }
  }
}
```

Shorthand possible:

If no `hook` is specified (`pre`/`on`/`post`) - will be treated as `on`:
```
SepCon.createComponent({id:'...'}, {
  state: {
    lifecycle: {
      mount() {...},
      attach() {...},
      change() {...}
    }
  }
}
```