### PR TITLE
Bug fix for component resume functionality + services modifications +…

### DIFF
--- a/src/classes/service.js
+++ b/src/classes/service.js
@@ -27,6 +27,8 @@ export default class Service {
             channels: {}
         };
 
+        this.formatCacheDefinitions('requests');
+        this.formatCacheDefinitions('channels');
 
         Object.keys(this.definition.requests).forEach(key => {
             this.scoped.requests[key] = this.buildRequest.bind(this, key);
@@ -40,10 +42,19 @@ export default class Service {
         });
 
         this.scoped.clearCache = (type, key, args) => {
-            if(!this.definition.cache[type] || !this.definition.cache[type][key]) {
+            if(!type) {
+                this.clearAllCacheOf('requests');
+                this.clearAllCacheOf('channels');
+            }
+            else if(!key) {
+                this.clearAllCacheOf(type);
+            }
+            else if(!this.definition.cache[type] || !this.definition.cache[type][key]) {
                 return;
             }
-            this.clearCache(this.definition.cache[type][key], type, key, args);
+            else {
+                this.clearCache(this.definition.cache[type][key], type, key, args);
+            }
         };
         this.scoped.getCache = (type, key, args) => {
             if(!this.definition.cache[type] || !this.definition.cache[type][key]) {
@@ -84,6 +95,20 @@ export default class Service {
 
         this.sequencer = new root.classes.Sequencer(this, root.sequencerConfig);
         this.sequencer.startSequence('mountBase');
+    }
+
+    formatCacheDefinitions(type) {
+        Object.keys(this.definition.cache[type]).forEach(key => {
+            if(this.definition.cache[type][key] === true) {
+                this.definition.cache[type][key] = {};
+            }
+        });
+    }
+
+    clearAllCacheOf(type) {
+        Object.keys(this.definition.cache[type]).forEach(key => {
+            this.clearCache(this.definition.cache[type][key], type, key);
+        });
     }
 
     getCache(config, type, key, args = []) {

--- a/src/root.js
+++ b/src/root.js
@@ -14,6 +14,7 @@ import { ComponentItem, ComponentDefinitionItem } from './classes/component.mapp
 import { ModifierItem } from './classes/modifier.mapping.js';
 
 import { DATA_CHANGED, ADD_COMPONENT } from './shared/constants';
+import ReferenceMap from './shared/reference.map.js';
 
 import sequencerConfig from './config/sequencer.config.js';
 import routerConfig from './config/router.config.js';
@@ -65,6 +66,9 @@ export default class Root {
 
         this.router.config(this.routerConfig);
         this.router.listen();
+
+        //for debugging purposes
+        this._getValueFromHash = ReferenceMap.get;
     }
 
     setConfiguration(config) {

--- a/src/shared/utils.common.js
+++ b/src/shared/utils.common.js
@@ -1,4 +1,4 @@
-import { TAG_PREFIX, TAG_IDENTIFIER } from './constants';
+import {TAG_PREFIX, TAG_IDENTIFIER} from './constants';
 
 export default {
     /**
@@ -16,8 +16,7 @@ export default {
 
         to = to || new from.constructor();
 
-        for (let name in from)
-        {
+        for (let name in from) {
             to[name] = typeof to[name] == 'undefined' ? this.clone(from[name], null) : to[name];
         }
 
@@ -26,12 +25,12 @@ export default {
 
     extend(base, extend) {
         let res = this.clone(base);
-        if(!res) {
+        if (!res) {
             res = {};
         }
         for (let i in extend) {
             if (res.hasOwnProperty(i)) {
-                if(typeof extend[i] === 'object') {
+                if (typeof extend[i] === 'object') {
                     res[i] = this.extend(base[i], extend[i]);
                 }
                 else {
@@ -46,7 +45,7 @@ export default {
     },
 
     concatMethods(meth1, meth2) {
-        return function() {
+        return function () {
             meth1.apply(this, arguments);
             return meth2.apply(this, arguments);
         };
@@ -58,20 +57,20 @@ export default {
      * @param action
      * @returns {string}
      */
-    hookString(hook, action){
+    hookString(hook, action) {
         return (hook ? `${hook}:` : '') + action;
     },
 
     buildUid() {
-        return parseInt(Date.now()*1000+Math.round(Math.random()*1000)).toString(36);
+        return parseInt(Date.now() * 1000 + Math.round(Math.random() * 1000)).toString(36);
     },
 
     formatValueForValidJSON(obj) {
-        if(obj === 0) return 0;
-        if(obj === undefined) return null;
-        if(typeof obj === 'object') {
-            if(obj instanceof Array) {
-                for(let i = 0, e = obj.length; i < e; i++) {
+        if (obj === 0) return 0;
+        if (obj === undefined) return null;
+        if (typeof obj === 'object') {
+            if (obj instanceof Array) {
+                for (let i = 0, e = obj.length; i < e; i++) {
                     obj[i] = this.formatValueForValidJSON(obj[i]);
                 }
             }
@@ -86,13 +85,13 @@ export default {
 
     //Component Functions
     isInDOM(element) {
-        if(!element) return false;
+        if (!element) return false;
         return document.body.contains(element);
     },
     isDeepNestedInSameComponent(element) {
         const path = this.getComponentElementsPath(element, true, true);
-        for(let i=0, e=path.length-1; i< e; i++) {
-            if(path[i] === element.tagName) return true;
+        for (let i = 0, e = path.length - 1; i < e; i++) {
+            if (path[i] === element.tagName) return true;
         }
         return false;
     },
@@ -101,18 +100,18 @@ export default {
         let parent;
         do {
             parent = child.parentNode;
-            if(!parent) break;
-            if(parent._componentElement || parent.tagName.toLowerCase().indexOf(TAG_PREFIX) === 0) {
+            if (!parent) break;
+            if (parent._componentElement || parent.tagName.toLowerCase().indexOf(TAG_PREFIX) === 0) {
                 return parent;
             }
             child = parent;
         }
-        while(parent.tagName.toLowerCase() != 'body');
+        while (parent.tagName.toLowerCase() != 'body');
         return false;
     },
     getComponentElementNameForPath(element) {
         let id = element.getAttribute(TAG_IDENTIFIER) || null;
-        if(!id) {
+        if (!id) {
             const siblings = this.getComponentElementSiblings(element);
             const siblingsIndex = this.getComponentElementIndex(element, siblings);
             id = '(' + siblingsIndex + ')';
@@ -126,30 +125,30 @@ export default {
         let path = [];
         do {
             parent = this.getParentComponentElement(child);
-            if(!typesOnly && parent.tagName) {
-                 path.push(this.getComponentElementNameForPath(parent));
+            if (!typesOnly && parent.tagName) {
+                path.push(this.getComponentElementNameForPath(parent));
             }
-            else if(parent.tagName) {
+            else if (parent.tagName) {
                 path.push(parent.tagName);
             }
             child = parent;
         }
-        while(parent);
+        while (parent);
         path.reverse();
-        if(!typesOnly) {
+        if (!typesOnly) {
             path.push(this.getComponentElementNameForPath(element));
         }
         else {
             path.push(element.tagName);
         }
-        if(asArray) return path;
+        if (asArray) return path;
         return path.join('>');
     },
     getComponentElementSiblings(element) {
         const parent = this.getParentComponentElement(element);
         let siblings = parent ? Array.from(parent.getElementsByTagName(element.tagName)) : [];
-        if(siblings.length > 1) {
-            siblings = siblings.filter((node)=> {
+        if (siblings.length > 1) {
+            siblings = siblings.filter((node) => {
                 if (node._componentElement && node._componentElement.parent === parent) return true;
                 return this.getParentComponentElement(node) === parent;
             });
@@ -157,20 +156,20 @@ export default {
         return siblings;
     },
     getComponentElementIndex(element, siblings) {
-        for(let i=0,e=siblings.length;i<e;i++){
-            if(siblings[i]===element) return i;
+        for (let i = 0, e = siblings.length; i < e; i++) {
+            if (siblings[i] === element) return i;
         }
         return 0;
     },
 
     getComponent(list, element) {
-        if(element.component && element.component.mapItem) return element.component.mapItem;
+        if (element.component && element.component.mapItem) return element.component.mapItem;
 
         const path = element._componentElement.path;
 
-        for(let i=0, e=list.length; i<e; i++) {
+        for (let i = 0, e = list.length; i < e; i++) {
             let _item = list[i];
-            if(_item &&
+            if (_item &&
                 (_item.element === element || _item.path === path)) {
                 element.component = _item.element.component;
                 _item.setElement(element);
@@ -182,27 +181,26 @@ export default {
     getLooseComponent(list, element) {
         const tagName = element.tagName;
         const id = element.getAttribute(TAG_IDENTIFIER);
-        let sameTagList = list.filter((_item)=>_item && _item.tag === tagName);
+        let sameTagList = list.filter((_item) => _item && _item.tag === tagName);
         let item = null;
-        sameTagList.forEach((_item)=>{
-            if(!item) {
+        if (id && tagName) {
+            for (let i = 0, e = sameTagList.length; i < e; i++) {
+                let _item = sameTagList[i];
                 const isSameIdentifier = _item.id === id;
                 const isSameTag = _item.tag === tagName;
                 if (isSameTag && isSameIdentifier) {
-                    item = _item;
+                    element.component = _item.element.component;
+                    _item.setElement(element);
+                    return _item;
                 }
             }
-        });
-
-        if(!id) {
-            item = this.getComponent(sameTagList, element);
         }
-        return item;
+        return this.getComponent(sameTagList, element);
     },
     getCookie(key) {
         return document.cookie.split(';').forEach(cookie => {
             const cookiePair = cookie.split('=');
-            if(cookiePair[0] === key) {
+            if (cookiePair[0] === key) {
                 return cookiePair[1];
             }
         });

--- a/test/performance.test.js
+++ b/test/performance.test.js
@@ -153,6 +153,11 @@ describe('Component Performance', ()=> {
         document.getElementById('ui-tests').appendChild(DIV);
     }).timeout(5000);
 
+    it('update all 1000 rows with global change', (done) => {
+        doneCaller.setDoneCb(done);
+        scope.modifier('globals').updateNumber();
+    }).timeout(5000);
+
     it('render 1000 rows in container', (done) => {
         let rowsHtml = rows.createTag()
             .methods({
@@ -169,5 +174,26 @@ describe('Component Performance', ()=> {
     it('update all 2000 rows with global change', (done) => {
         doneCaller.setDoneCb(done);
         scope.modifier('globals').updateNumber();
+    }).timeout(5000);
+
+
+    it('render 10000(!) rows', (done) => {
+        const max = 10000;
+        let rows = [];
+        for (let i = 0; i < max; i++) {
+            const current = row.createTag();
+            current.id(i);
+            if (i === max - 1) {
+                current
+                    .methods({
+                        changeCb: doneCaller.callDone,
+                        firstRenderCb: done
+                    });
+            }
+            rows.push(current.render());
+        }
+        let DIV = document.createElement('div');
+        DIV.innerHTML = rows.join('');
+        document.getElementById('ui-tests').appendChild(DIV);
     }).timeout(5000);
 });


### PR DESCRIPTION
… debug ReferenceMap

**Component Resume:**
Had an issue with resuming properly components after being re-drawn at the DOM, didn't properly set up the element to resume with existing component instance.

`./shared/utils.common` -> `getLooseComponent`
- Now test properly if an ID is actually set (rather then the use-case of an undefined ID causing a lot of different elements accidentally match)
- Assigning the mapItem to `component` property of the DOM node itself, and updating the element at the mapItem responsively (same behavior as in the `getComponent` method
- Changed iteration to a for loop so it could be easily escaped once the exact component found, and will start the for loop ONLY if the component-element has an ID - optimizing the performance of initiating/resuming an element in the DOM

**Services Modification:**
Added better support for shorthanding cache definition as well as a support of an easy collective `clearCache` functionality.

- We could set now a cache definition by passing only `true` as a value rather then an object with default values:
   ```javascript
   cache: {
       requests: {
           someRequest: true
       }
   }
   ```
   Will be equivalent to:
   ```javascript
   cache: {
       requests: {
           someRequest: {
               storage: 'local',
               duration: false
           }
       }
   }
   ```
- Now it will be supported to use `clearCache` without passing arguments to clear ALL cache stored, or passing just the type - `'requests' / 'channels'` which will clear ALL cache stored for `'requests' / 'channels'` responsively

**Debug ReferenceMap:**
Added a reference to the `root` instance to point directly to `ReferenceMap.get` method.
i.e. - we could take values directly from the DOM component elements, pass them to `SepCon.root._getValueFromHash(SOME_HASH)` and get the actual value